### PR TITLE
Refactor main.tf parser, add CLI/config envs, improve error handling, and update Docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:slim
+FROM python:3.14
 WORKDIR /oci
 COPY . .
 RUN pip install --use-pep517 --no-cache-dir -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,18 +1,29 @@
-### 仅支持密钥登录，需要密码生成的请自行修改`oracle_arm.py`
-## 步骤
-### 一、新建`data`文件夹，编辑`.env`、`config`文件以及私钥`p.pem`并保存到`data`文件夹内
-#### `.env`文件按以下格式保存内容
+### Oracle ARM 抢注脚本
+
+该脚本使用 Oracle Cloud Infrastructure Python SDK 创建 `VM.Standard.A1.Flex` 实例。当前代码已按新版 OCI SDK 的调用方式保留 `LaunchInstanceDetails` / `LaunchInstanceShapeConfigDetails` / `CreateVnicDetails` / `InstanceSourceViaImageDetails`，并增强了 `main.tf` 解析、错误处理和运行参数。
+
+> 仅支持密钥登录，需要密码生成的请自行修改 `oracle_arm.py`。
+
+## 运行前准备
+
+### 一、新建 `data` 文件夹，编辑 `.env`、`config` 文件以及私钥 `p.pem` 并保存到 `data` 文件夹内
+
+#### `.env` 文件按以下格式保存内容
+
 ```bash
 USE_TG=True
 TG_BOT_TOKEN=123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ
 TG_USER_ID=987654321
 TG_API_HOST=api.telegram.org
 ```
-- `USE_TG=True`启用电报通知，如不需要可将`True`改为`False`，自行在日志内查看具体情况
-- `TG_BOT_TOKEN`填写电报机器人TOKEN
-- `TG_USER_ID`填写用户、频道或群组ID
-- `TG_API_HOST`填写电报自建API反代地址，供网络环境无法访问时使用，网络正常则保持默认
-#### `config`文件按以下格式保存内容
+
+- `USE_TG=True` 启用电报通知，如不需要可将 `True` 改为 `False`，自行在日志内查看具体情况。
+- `TG_BOT_TOKEN` 填写电报机器人 TOKEN。
+- `TG_USER_ID` 填写用户、频道或群组 ID。
+- `TG_API_HOST` 填写电报自建 API 反代地址，供网络环境无法访问时使用，网络正常则保持默认。
+
+#### `config` 文件按以下格式保存内容
+
 ```bash
 [DEFAULT]
 user=ocid1.user.oc1..aaaaaaxxxxxxxxxxxxxxxxxxxxxxxxxxxx
@@ -21,19 +32,64 @@ key_file=/opt/oci/p.pem
 tenancy=ocid1.tenancy.oc1..aaaaaaaxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 region=us-ashburn-1
 ```
-- `user`、`fingerprint`、`tenancy`、`region`的取值请参考[甲骨文官方文档](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm#SDK_and_CLI_Configuration_File#ariaid-title3)
-#### `key_file`指定私钥文件，文件名可修改，位置建议不做改动（该位置为docker内文件存放地址，如有修改请自行调整所有相关文件配置），私钥获取方式建议参考[官方文档](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#ariaid-title3)的`To generate an API signing key pair`
-### 二、参考[大鸟博客](https://www.daniao.org/14121.html)的`1、生成main.tf`获取`main.tf`文件，保存到与`data`文件夹相同的目录层
-### 三、新建`docker-compose.yml`文件，粘贴以下内容并保存到与`data`文件夹相同的目录层
-```bash
+
+- `user`、`fingerprint`、`tenancy`、`region` 的取值请参考[甲骨文官方文档](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm#SDK_and_CLI_Configuration_File#ariaid-title3)。
+- `key_file` 指定私钥文件，文件名可修改，位置建议不做改动（该位置为 Docker 内文件存放地址，如有修改请同步调整配置）。私钥获取方式建议参考[官方文档](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#ariaid-title3)的 `To generate an API signing key pair`。
+
+### 二、准备 `main.tf`
+
+参考[大鸟博客](https://www.daniao.org/14121.html)的 `1、生成main.tf` 获取 `main.tf` 文件，保存到与 `data` 文件夹相同的目录层。
+
+脚本会读取以下字段：
+
+- `compartment_id`
+- `memory_in_gbs`
+- `ocpus`
+- `availability_domain`
+- `subnet_id`
+- `display_name`
+- `source_id`
+- `boot_volume_size_in_gbs`（可选，缺省为 `50`）
+- `ssh_authorized_keys`
+
+新版解析器兼容 `ocpus = 4` 和 `ocpus = "4"` 两种 Terraform 写法。
+
+### 三、新建 `docker-compose.yml`
+
+粘贴以下内容并保存到与 `data` 文件夹相同的目录层：
+
+```yaml
 services:
   oci:
-    image: sheepgreen/oracle-arm #或使用github镜像ghcr.io/slippersheepig/oracle-arm
+    image: sheepgreen/oracle-arm # 或使用 github 镜像 ghcr.io/slippersheepig/oracle-arm
     container_name: oci
     volumes:
       - ./data:/opt/oci
       - ./main.tf:/oci/main.tf
 ```
-### 四、附上文件位置图
+
+### 四、启动
+
+```bash
+docker-compose up -d
+```
+
+## 可选环境变量
+
+如需改变默认挂载路径或配置名称，可设置：
+
+- `OCI_ARM_CONFIG_DIR`：默认 `/opt/oci`。
+- `OCI_ARM_DOTENV`：默认 `${OCI_ARM_CONFIG_DIR}/.env`。
+- `OCI_ARM_OCI_CONFIG`：默认 `${OCI_ARM_CONFIG_DIR}/config`。
+- `OCI_ARM_OCI_PROFILE`：默认 `DEFAULT`。
+- `OCI_ARM_TF_PATH`：默认 `main.tf`。
+
+也可以直接传入 `main.tf` 路径：
+
+```bash
+python oracle_arm.py /path/to/main.tf
+```
+
+## 文件位置示例
+
 ![1b224fae4533f397be7b93fd67725f2c](https://github.com/slippersheepig/oracle_arm/assets/58287293/15bb7a67-92ed-41f7-9136-826175c477ca)
-### 五、输入`docker-compose up -d`即启动成功

--- a/oracle_arm.py
+++ b/oracle_arm.py
@@ -1,21 +1,31 @@
-import oci
-import re
-import time
-from oci.core import ComputeClient, VirtualNetworkClient
-from oci.config import validate_config
-import sys
-import requests
+import argparse
+import os
 import random
-import base64
-from dotenv import dotenv_values
+import re
+import sys
+import time
+from pathlib import Path
 
-config = dotenv_values("/opt/oci/.env")
+import oci
+import requests
+from dotenv import dotenv_values
+from oci.config import validate_config
+from oci.core import ComputeClient, VirtualNetworkClient
+
+DEFAULT_CONFIG_DIR = os.getenv("OCI_ARM_CONFIG_DIR", "/opt/oci")
+DEFAULT_DOTENV_PATH = os.getenv("OCI_ARM_DOTENV", str(Path(DEFAULT_CONFIG_DIR) / ".env"))
+DEFAULT_OCI_CONFIG_PATH = os.getenv("OCI_ARM_OCI_CONFIG", str(Path(DEFAULT_CONFIG_DIR) / "config"))
+DEFAULT_OCI_PROFILE = os.getenv("OCI_ARM_OCI_PROFILE", "DEFAULT")
+DEFAULT_TF_PATH = os.getenv("OCI_ARM_TF_PATH", "main.tf")
+
+config = dotenv_values(DEFAULT_DOTENV_PATH)
 
 
 def _to_bool(value, default=False):
     if value is None:
         return default
     return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
 
 # tg pusher config
 USE_TG = _to_bool(config.get("USE_TG"), default=False)  # 如果启用tg推送 要设置为True
@@ -28,42 +38,45 @@ def telegram(desp):
     if not USE_TG:
         return
     if not (TG_BOT_TOKEN and TG_USER_ID and TG_API_HOST):
-        print('Telegram Bot 配置缺失，跳过推送')
+        print("Telegram Bot 配置缺失，跳过推送")
         return
-    data = (('chat_id', TG_USER_ID), ('text', '🐢甲骨文ARM抢注脚本为您播报🐢 \n\n' + desp))
-    response = requests.post('https://' + TG_API_HOST + '/bot' + TG_BOT_TOKEN +
-                             '/sendMessage',
-                             data=data,
-                             timeout=10)
-    if response.status_code != 200:
-        print('Telegram Bot 推送失败')
+    data = (("chat_id", TG_USER_ID), ("text", "🐢甲骨文ARM抢注脚本为您播报🐢 \n\n" + desp))
+    try:
+        response = requests.post(
+            "https://" + TG_API_HOST + "/bot" + TG_BOT_TOKEN + "/sendMessage",
+            data=data,
+            timeout=10,
+        )
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        print(f"Telegram Bot 推送失败: {exc}")
     else:
-        print('Telegram Bot 推送成功')
+        print("Telegram Bot 推送成功")
 
 
 class OciUser:
     """
     oci 用户配置文件的类
     """
+
     user: str
     fingerprint: str
     key_file: str
     tenancy: str
     region: str
 
-    def __init__(self, configfile="/opt/oci/config", profile="DEFAULT"):
-        cfg = oci.config.from_file(file_location=configfile,
-                                   profile_name=profile)
+    def __init__(self, configfile=DEFAULT_OCI_CONFIG_PATH, profile=DEFAULT_OCI_PROFILE):
+        cfg = oci.config.from_file(file_location=configfile, profile_name=profile)
         validate_config(cfg)
         self.parse(cfg)
 
     def parse(self, cfg) -> None:
         print("parser cfg")
-        self.user = cfg['user']
+        self.user = cfg["user"]
         self.fingerprint = cfg["fingerprint"]
         self.key_file = cfg["key_file"]
-        self.tenancy = cfg['tenancy']
-        self.region = cfg['region']
+        self.tenancy = cfg["tenancy"]
+        self.region = cfg["region"]
 
     def keys(self):
         return ("user", "fingerprint", "key_file", "tenancy", "region")
@@ -76,65 +89,61 @@ class OciUser:
 
 
 class FileParser:
+    ASSIGNMENT_RE = re.compile(r'^\s*([A-Za-z0-9_".-]+)\s*=\s*(.+?)\s*(?:#.*)?$', re.MULTILINE)
+
     def __init__(self, file_path: str) -> None:
         self.parser(file_path)
 
     def parser(self, file_path):
-        # compoartment id
-        # print("开始解析参数")
-
         try:
             print("filepath", file_path)
-            f = open(file_path, "r")
-            self._filebuf = f.read()
-            f.close()
+            with open(file_path, "r", encoding="utf-8") as file_obj:
+                self._filebuf = file_obj.read()
+        except OSError as exc:
+            raise SystemExit(f"main.tf文件打开失败,请再一次确认执行了正确操作,脚本退出: {exc}") from exc
 
-        except Exception as e:
-            print("main.tf文件打开失败,请再一次确认执行了正确操作,脚本退出", e)
-            exit(0)
+        values = self._parse_assignments(self._filebuf)
+        self.compoartment_id = self._required(values, "compartment_id")
+        self.memory_in_gbs = self._required_float(values, "memory_in_gbs")
+        self.ocpus = self._required_float(values, "ocpus")
+        self.availability_domain = self._required(values, "availability_domain")
+        self.subnet_id = self._required(values, "subnet_id")
+        self.display_name = self._required(values, "display_name").strip().replace(" ", "-")
+        self.image_id = self._required(values, "source_id")
+        self.boot_volume_size_in_gbs = self._optional_float(values, "boot_volume_size_in_gbs", 50.0)
+        self.ssh_authorized_keys = self._required(values, "ssh_authorized_keys")
 
-        compoartment_pat = re.compile('compartment_id = "(.*)"')
-        self.compoartment_id = compoartment_pat.findall(self._filebuf).pop()
+    @classmethod
+    def _parse_assignments(cls, content):
+        values = {}
+        for key, raw_value in cls.ASSIGNMENT_RE.findall(content):
+            clean_key = key.strip('"')
+            clean_value = raw_value.strip().rstrip(",").strip()
+            if clean_value.startswith('"') and clean_value.endswith('"'):
+                clean_value = clean_value[1:-1]
+            values.setdefault(clean_key, []).append(clean_value)
+        return values
 
-        # 内存
-        memory_pat = re.compile('memory_in_gbs = "(.*)"')
-        self.memory_in_gbs = float(memory_pat.findall(self._filebuf).pop())
-        # 查找cpu个数
-        cpu_pat = re.compile('ocpus = "(.*)"')
-        self.ocpus = float(cpu_pat.findall(self._filebuf).pop())
-
-        # 可用域
-        ava_domain_pat = re.compile('availability_domain = "(.*)"')
-
-        self.availability_domain = ava_domain_pat.findall(self._filebuf).pop()
-
-        # 子网id
-        subnet_pat = re.compile('subnet_id = "(.*)"')
-        self.subnet_id = subnet_pat.findall(self._filebuf).pop()
-        # 实例名称
-        disname_pat = re.compile('display_name = "(.*)"')
-        disname = disname_pat.findall(self._filebuf).pop()
-        self.display_name = disname.strip().replace(" ", "-")
-
-        # imageid
-        imageid_pat = re.compile('source_id = "(.*)"')
-        self.image_id = imageid_pat.findall(self._filebuf)[0]
-        # 硬盘大小
-        oot_volume_size_in_gbs_pat = re.compile(
-            'boot_volume_size_in_gbs = "(.*)"')
+    @staticmethod
+    def _required(values, key):
         try:
-            self.boot_volume_size_in_gbs = float(
-                oot_volume_size_in_gbs_pat.findall(self._filebuf).pop())
-        except IndexError:
-            self.boot_volume_size_in_gbs = 50.0
+            return values[key][-1]
+        except (KeyError, IndexError) as exc:
+            raise ValueError(f"main.tf缺少必要参数: {key}") from exc
 
-        # print("硬盘大小", self.boot_volume_size_in_gbs)
-        # 读取密钥
-        ssh_rsa_pat = re.compile('"ssh_authorized_keys" = "(.*)"')
+    @classmethod
+    def _required_float(cls, values, key):
+        raw_value = cls._required(values, key)
         try:
-            self.ssh_authorized_keys = ssh_rsa_pat.findall(self._filebuf).pop()
-        except Exception as e:
-            print("推荐创建堆栈的时候下载ssh key，理论上是可以不用的，但是我没写😂,麻烦重新创建吧")
+            return float(raw_value)
+        except ValueError as exc:
+            raise ValueError(f"main.tf参数 {key} 必须是数字，当前值: {raw_value}") from exc
+
+    @classmethod
+    def _optional_float(cls, values, key, default):
+        if key not in values:
+            return default
+        return cls._required_float(values, key)
 
     @property
     def ssh_authorized_keys(self):
@@ -210,71 +219,39 @@ class FileParser:
 
 
 class InsCreate:
-    shape = 'VM.Standard.A1.Flex'
-    sleep_time = random.uniform(3, 6)
-    try_count = 0
-    desp = ""
+    shape = "VM.Standard.A1.Flex"
 
     def __init__(self, user: OciUser, filepath) -> None:
         self._user = user
         self._client = ComputeClient(config=dict(user))
         self.tf = FileParser(filepath)
-
-#    def gen_pwd(self):
-#        passwd = ''.join(
-#            random.sample(
-#                'ZYXWVUTSRQPONMLKJIHGFEDCBAzyxwvutsrqponmlkjihgfedcba#@1234567890',
-#                13))
-#        print("创建ssh登录密码:{}\n".format(passwd))
-#        self._pwd = passwd
-#        sh = '#!/bin/bash \n    echo root:' + passwd + " | sudo chpasswd root\n    sudo sed -i 's/^.*PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config;\n    sudo sed -i 's/^.*PasswordAuthentication.*/PasswordAuthentication yes/g' /etc/ssh/sshd_config;\n    sudo reboot"
-#        sh64 = base64.b64encode(sh.encode('utf-8'))
-#        sh64 = str(sh64, 'utf-8')
-#        self._slcmd = sh64
+        self.sleep_time = random.uniform(3, 6)
+        self.try_count = 0
+        self.desp = ""
+        self.ins_id = None
+        self.public_ip = None
 
     def create(self):
-        # print("已运行创建活动")
-        # 开启一个tg的原始推送
         text = "脚本开始启动:\n,区域:{}-实例:{},CPU:{}C-内存:{}G-硬盘:{}G的小🐔已经快马加鞭抢购了\n".format(
-            self.tf.availability_domain, self.tf.display_name, self.tf.ocpus,
-            self.tf.memory_in_gbs, self.tf.boot_volume_size_in_gbs)
+            self.tf.availability_domain,
+            self.tf.display_name,
+            self.tf.ocpus,
+            self.tf.memory_in_gbs,
+            self.tf.boot_volume_size_in_gbs,
+        )
         telegram(text)
-#        self.gen_pwd()
         while True:
             try:
-                ins = self.lunch_instance()  # 应该返回具体的成功的数据
-            except oci.exceptions.ServiceError as e:
-                if e.status == 429 and e.code == 'TooManyRequests' and e.message == 'Too many requests for the user':
-                    # 被限速了，改一下时间
-                    print("请求太快了，自动调整请求时间ing")
-                    if self.sleep_time < 60:
-                        self.sleep_time += random.uniform(3, 6)
-                elif not (e.status == 500 and e.code == 'InternalError'
-                          and e.message == 'Out of host capacity.'):
-                    if "Service limit" in e.message and e.status==400:
-                        # 可能是别的错误，也有可能是 达到上限了，要去查看一下是否开通成功，也有可能错误了
-                        self.logp("❌如果看到这条推送,说明刷到机器，但是开通失败了，请后台检查你的cpu，内存，硬盘占用情况，并释放对应的资源 返回值:{},\n 脚本停止".format(e))
-                        telegram(self.desp)
-                        raise e
-                    else:
-                        print("❌发生错误:{}".format(e))
-                        telegram("❌发生错误:{}".format(e))
-                    # raise e
-                else:
-                    # 没有被限速，恢复减少的时间
-                    print("目前没有请求限速,快马加刷中")
-                    if self.sleep_time > 15:
-                        self.sleep_time -= random.uniform(3, 6)
-                print("本次返回信息:",e)
+                ins = self.launch_instance()
+            except oci.exceptions.ServiceError as exc:
+                self.handle_service_error(exc)
                 time.sleep(self.sleep_time)
-            except oci.exceptions.RequestException as e:
-                re_text = "❌发生错误:{}".format(e)
+            except oci.exceptions.RequestException as exc:
+                re_text = "❌发生错误:{}".format(exc)
                 print(re_text)
                 telegram(re_text)
+                time.sleep(self.sleep_time)
             else:
-                #  开通成功 ，ins 就是返回的数据
-                #  可以等一会去请求实例的ip
-                # print("开通成功之后的ins:\n\n", ins, type(ins))
                 self.logp(
                     "🎉经过 {} 尝试后\n 区域:{}实例:{}-CPU:{}C-内存:{}G🐔创建成功了🎉\n".format(
                         self.try_count + 1,
@@ -282,9 +259,9 @@ class InsCreate:
                         self.tf.display_name,
                         self.tf.ocpus,
                         self.tf.memory_in_gbs,
-                    ))
+                    )
+                )
                 self.ins_id = ins.id
-#                self.logp("ssh登陆密码: {} \n".format(self._pwd))
                 self.check_public_ip()
                 telegram(self.desp)
                 break
@@ -295,45 +272,75 @@ class InsCreate:
                 if self.try_count % 100 == 0:
                     telegram(count_text)
 
+    def handle_service_error(self, exc):
+        if exc.status == 429 and exc.code == "TooManyRequests":
+            print("请求太快了，自动调整请求时间ing")
+            if self.sleep_time < 60:
+                self.sleep_time += random.uniform(3, 6)
+        elif self.is_capacity_error(exc):
+            print("目前没有请求限速,快马加刷中")
+            if self.sleep_time > 15:
+                self.sleep_time -= random.uniform(3, 6)
+        elif exc.status == 400 and "Service limit" in str(exc.message):
+            self.logp(
+                "❌如果看到这条推送,说明刷到机器，但是开通失败了，请后台检查你的cpu，内存，硬盘占用情况，并释放对应的资源 返回值:{},\n 脚本停止".format(exc)
+            )
+            telegram(self.desp)
+            raise exc
+        else:
+            print("❌发生错误:{}".format(exc))
+            telegram("❌发生错误:{}".format(exc))
+        print("本次返回信息:", exc)
+
+    @staticmethod
+    def is_capacity_error(exc):
+        message = str(getattr(exc, "message", "")).lower()
+        return exc.status in {400, 500} and "out of host capacity" in message
+
     def check_public_ip(self):
         network_client = VirtualNetworkClient(config=dict(self._user))
-        count=100
+        count = 100
         while count:
             attachments = self._client.list_vnic_attachments(
-                compartment_id=self._user.compartment_id(),
-                instance_id=self.ins_id)
+                compartment_id=self._user.compartment_id(), instance_id=self.ins_id
+            )
             data = attachments.data
-            if len(data) != 0:
+            if data:
                 print("开始查找vnic id ")
                 vnic_id = data[0].vnic_id
                 public_ip = network_client.get_vnic(vnic_id).data.public_ip
                 self.logp("公网ip为:{}\n 🐢脚本停止，感谢使用😄\n".format(public_ip))
                 self.public_ip = public_ip
-                return 
+                return
             time.sleep(5)
-            count-=1
+            count -= 1
         self.logp("开机失败，被他娘甲骨文给关掉了😠，脚本停止，请重新运行\n")
-        
-    def lunch_instance(self):
+
+    def launch_instance(self):
         return self._client.launch_instance(
             oci.core.models.LaunchInstanceDetails(
                 display_name=self.tf.display_name,
                 compartment_id=self.tf.compoartment_id,
                 shape=self.shape,
-#                extended_metadata={'user_data': self._slcmd},
                 shape_config=oci.core.models.LaunchInstanceShapeConfigDetails(
-                    ocpus=self.tf.ocpus, memory_in_gbs=self.tf.memory_in_gbs),
+                    ocpus=self.tf.ocpus, memory_in_gbs=self.tf.memory_in_gbs
+                ),
                 availability_domain=self.tf.availability_domain,
                 create_vnic_details=oci.core.models.CreateVnicDetails(
-                    subnet_id=self.tf.subnet_id,
-                    hostname_label=self.tf.display_name),
+                    subnet_id=self.tf.subnet_id, hostname_label=self.tf.display_name
+                ),
                 source_details=oci.core.models.InstanceSourceViaImageDetails(
                     image_id=self.tf.image_id,
                     boot_volume_size_in_gbs=self.tf.boot_volume_size_in_gbs,
                 ),
                 metadata=dict(ssh_authorized_keys=self.tf.ssh_authorized_keys),
                 is_pv_encryption_in_transit_enabled=True,
-            )).data
+            )
+        ).data
+
+    # 兼容旧代码/外部调用里已有的拼写错误方法名。
+    def lunch_instance(self):
+        return self.launch_instance()
 
     def logp(self, text):
         print(text)
@@ -341,8 +348,18 @@ class InsCreate:
             self.desp += text
 
 
-if __name__ == "__main__":
+def parse_args(argv):
+    parser = argparse.ArgumentParser(description="Oracle Cloud ARM VM 抢注脚本")
+    parser.add_argument("main_tf", nargs="?", default=DEFAULT_TF_PATH, help="main.tf 文件路径，默认: %(default)s")
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv if argv is not None else sys.argv[1:])
     user = OciUser()
-    path = sys.argv[1]
-    ins = InsCreate(user, path)
+    ins = InsCreate(user, args.main_tf)
     ins.create()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

- Make the ARM VM抢注脚本 more robust and configurable by adding CLI arguments and environment-variable driven defaults for config locations.  
- Improve resiliency of parsing `main.tf` so the script tolerates different Terraform value formats and reports missing/invalid fields.  
- Harden network/OCI error handling and Telegram notification logic to reduce silent failures and keep backwards compatibility for older call sites.

### Description

- Update `Dockerfile` to use `FROM python:3.14` instead of `python:slim`.  
- Expand and rewrite `README.md` with clearer usage, supported `main.tf` fields, and new optional environment variables `OCI_ARM_*`.  
- Rework `oracle_arm.py` to add CLI parsing (`argparse`) and environment-driven defaults (`OCI_ARM_CONFIG_DIR`, `OCI_ARM_DOTENV`, `OCI_ARM_OCI_CONFIG`, `OCI_ARM_OCI_PROFILE`, `OCI_ARM_TF_PATH`).  
- Replace brittle `main.tf` extraction with a robust `FileParser` that tokenizes assignments, provides `_required`, `_required_float`, and `_optional_float` helpers, validates required fields (including `ssh_authorized_keys`) and sets sensible defaults (e.g. `boot_volume_size_in_gbs=50`), while supporting both numeric and quoted numeric `ocpus` forms.  
- Improve notification and error handling by adding exception handling around Telegram requests, a centralized `handle_service_error` for OCI `ServiceError` cases (rate limiting, capacity, service limit), refined retry/sleep logic, and public IP discovery; expose `launch_instance` and keep `lunch_instance` as a compatibility shim.  

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2eaaaf8ef483329d2d4f0d042f5065)